### PR TITLE
Reformats preferences to take a list, adds belch pref to emote

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -268,13 +268,6 @@
 					'sound/vore/belches/belch9.ogg','sound/vore/belches/belch10.ogg','sound/vore/belches/belch11.ogg','sound/vore/belches/belch12.ogg',
 					'sound/vore/belches/belch13.ogg','sound/vore/belches/belch14.ogg','sound/vore/belches/belch15.ogg')
 			//END VORESTATION EDIT
-			//CHOMPEdit Begin
-			if ("belches") soundin = pick(
-					'sound/vore/belches/belch1.ogg','sound/vore/belches/belch2.ogg','sound/vore/belches/belch3.ogg','sound/vore/belches/belch4.ogg',
-					'sound/vore/belches/belch5.ogg','sound/vore/belches/belch6.ogg','sound/vore/belches/belch7.ogg','sound/vore/belches/belch8.ogg',
-					'sound/vore/belches/belch9.ogg','sound/vore/belches/belch10.ogg','sound/vore/belches/belch11.ogg','sound/vore/belches/belch12.ogg',
-					'sound/vore/belches/belch13.ogg','sound/vore/belches/belch14.ogg','sound/vore/belches/belch15.ogg',)
-			//CHOMPEdit End
 			if ("terminal_type")
 				soundin = pick('sound/machines/terminal_button01.ogg', 'sound/machines/terminal_button02.ogg', 'sound/machines/terminal_button03.ogg', \
 								'sound/machines/terminal_button04.ogg', 'sound/machines/terminal_button05.ogg', 'sound/machines/terminal_button06.ogg', \

--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -83,9 +83,17 @@
 
 	return ..()
 
+/**
+ * This can take either a single preference datum or a list of preferences, and will return true if *all* preferences in the arguments are enabled.
+ */ 
 /client/proc/is_preference_enabled(var/preference)
-	var/datum/client_preference/cp = get_client_preference(preference)
-	return cp && (cp.key in prefs.preferences_enabled)
+	if(!islist(preference))
+		preference = list(preference)
+	for(var/p in preference)
+		var/datum/client_preference/cp = get_client_preference(p)
+		if(!cp || !(cp.key in prefs.preferences_enabled))
+			return FALSE
+	return TRUE
 
 /client/proc/set_preference(var/preference, var/set_preference)
 	var/datum/client_preference/cp = get_client_preference(preference)

--- a/code/modules/emotes/definitions/audible_belch.dm
+++ b/code/modules/emotes/definitions/audible_belch.dm
@@ -2,6 +2,7 @@
 	key = "belch"
 	emote_message_3p = "belches."
 	message_type = AUDIBLE_MESSAGE
+	sound_preferences = list(/datum/client_preference/emote_noises,/datum/client_preference/belch_noises)
 
 /decl/emote/audible/belch/get_emote_sound(var/atom/user)
 	return list(

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -42,6 +42,8 @@ var/global/list/emotes_by_key
 	var/check_range                                     // falsy, or a range outside which the emote will not work
 	var/conscious = TRUE                                // Do we need to be awake to emote this?
 	var/emote_range = 0                                 // If >0, restricts emote visibility to viewers within range.
+	
+	var/sound_preferences = list(/datum/client_preference/emote_noises)
 
 /decl/emote/Initialize()
 	. = ..()
@@ -176,7 +178,7 @@ var/global/list/emotes_by_key
 		if(islist(sound_to_play) && length(sound_to_play))
 			sound_to_play = pick(sound_to_play)
 	if(sound_to_play)
-		playsound(user.loc, sound_to_play, use_sound["vol"], 0, preference = /datum/client_preference/emote_noises) //VOREStation Add - Preference
+		playsound(user.loc, sound_to_play, use_sound["vol"], 0, preference = sound_preferences) //VOREStation Add - Preference
 
 /decl/emote/proc/mob_can_use(var/mob/user)
 	return istype(user) && user.stat != DEAD && (type in user.get_available_emotes())


### PR DESCRIPTION
Preferences can now take a list instead of a singular datum (but will still accept a singular datum for legacy compat), and any arguments that check is_preference_enabled must return true on all prefs from the list, not just one.
